### PR TITLE
Add Monge-Ampere zoom plot and tangling exercise

### DIFF
--- a/demos/monge_ampere1.py
+++ b/demos/monge_ampere1.py
@@ -103,6 +103,20 @@ plt.savefig("monge_ampere1-adapted_mesh.jpg")
 #    :figwidth: 60%
 #    :align: center
 #
+# Whilst it looks like the mesh might have tangled elements, closer inspection shows
+# that this is not the case.
+
+fig, axes = plt.subplots()
+triplot(mover.mesh, axes=axes)
+axes.set_xlim([0.15, 0.3])
+axes.set_ylim([0.15, 0.3])
+axes.set_aspect(1)
+plt.savefig("monge_ampere1-adapted_mesh_zoom.jpg")
+
+# .. figure:: monge_ampere1-adapted_mesh_zoom.jpg
+#    :figwidth: 60%
+#    :align: center
+#
 # This tutorial can be dowloaded as a `Python script <monge_ampere1.py>`__.
 #
 #

--- a/demos/monge_ampere1.py
+++ b/demos/monge_ampere1.py
@@ -117,6 +117,13 @@ plt.savefig("monge_ampere1-adapted_mesh_zoom.jpg")
 #    :figwidth: 60%
 #    :align: center
 #
+# .. rubric:: Exercise
+#
+# To further convince yourself that there are no tangled elements, go back to the start
+# of the demo and set up a :class:`movement.tangling.MeshTanglingChecker` object using
+# the initial mesh. Use it to check for tangling after the mesh movement has been
+# applied.
+#
 # This tutorial can be dowloaded as a `Python script <monge_ampere1.py>`__.
 #
 #

--- a/movement/tangling.py
+++ b/movement/tangling.py
@@ -60,7 +60,8 @@ class MeshTanglingChecker:
         sj = self.scaled_jacobian.dat.data_with_halos
         num_tangled = len(sj[sj < 0])
         if num_tangled > 0:
-            msg = f"Mesh has {num_tangled} tangled elements."
+            plural = "s" if num_tangled > 1 else ""
+            msg = f"Mesh has {num_tangled} tangled element{plural}."
             if self.raise_error:
                 raise ValueError(msg)
             warnings.warn(msg)

--- a/test/test_tangling.py
+++ b/test/test_tangling.py
@@ -8,16 +8,25 @@ class TestTangling(unittest.TestCase):
     Unit tests for mesh tangling checking.
     """
 
-    def test_tangling_checker_error(self):
+    def test_tangling_checker_error1(self):
         mesh = UnitSquareMesh(3, 3)
         checker = MeshTanglingChecker(mesh, raise_error=True)
         mesh.coordinates.dat.data[3] += 0.2
         with self.assertRaises(ValueError) as cm:
             checker.check()
-        msg = "Mesh has 1 tangled elements."
+        msg = "Mesh has 1 tangled element."
         self.assertEqual(str(cm.exception), msg)
 
-    def test_tangling_checker_warning(self):
+    def test_tangling_checker_error2(self):
+        mesh = UnitSquareMesh(3, 3)
+        checker = MeshTanglingChecker(mesh, raise_error=True)
+        mesh.coordinates.dat.data[3] += 0.5
+        with self.assertRaises(ValueError) as cm:
+            checker.check()
+        msg = "Mesh has 3 tangled elements."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_tangling_checker_warning1(self):
         mesh = UnitSquareMesh(3, 3)
         checker = MeshTanglingChecker(mesh, raise_error=False)
         self.assertEqual(checker.check(), 0)

--- a/test/test_tangling.py
+++ b/test/test_tangling.py
@@ -1,15 +1,25 @@
 from firedrake import *
 from movement import *
+import unittest
 
 
-def test_tangling_checker():
+class TestTangling(unittest.TestCase):
     """
-    Test that :class:`MeshTanglingChecker`
-    can correctly identify tangled elements
-    in a 2D triangular mesh.
+    Unit tests for mesh tangling checking.
     """
-    mesh = UnitSquareMesh(3, 3)
-    checker = MeshTanglingChecker(mesh, raise_error=False)
-    assert checker.check() == 0
-    mesh.coordinates.dat.data[3] += 0.2
-    assert checker.check() == 1
+
+    def test_tangling_checker_error(self):
+        mesh = UnitSquareMesh(3, 3)
+        checker = MeshTanglingChecker(mesh, raise_error=True)
+        mesh.coordinates.dat.data[3] += 0.2
+        with self.assertRaises(ValueError) as cm:
+            checker.check()
+        msg = "Mesh has 1 tangled elements."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_tangling_checker_warning(self):
+        mesh = UnitSquareMesh(3, 3)
+        checker = MeshTanglingChecker(mesh, raise_error=False)
+        self.assertEqual(checker.check(), 0)
+        mesh.coordinates.dat.data[3] += 0.2
+        self.assertEqual(checker.check(), 1)

--- a/test/test_tangling.py
+++ b/test/test_tangling.py
@@ -9,7 +9,7 @@ def test_tangling_checker():
     in a 2D triangular mesh.
     """
     mesh = UnitSquareMesh(3, 3)
-    checker = MeshTanglingChecker(mesh)
+    checker = MeshTanglingChecker(mesh, raise_error=False)
     assert checker.check() == 0
     mesh.coordinates.dat.data[3] += 0.2
     assert checker.check() == 1


### PR DESCRIPTION
Closes #50. Partly addresses #19.

This PR adds a zoom plot to the first Monge-Ampere demo to show that the elements aren't tangled, as well as an exercise to check this with `MeshTanglingChecker`.

The PR also applies some minor refactoring to `MeshTanglingChecker`, as well as writing unit tests for it.